### PR TITLE
Wire stub components and middleware

### DIFF
--- a/template/app/package.json
+++ b/template/app/package.json
@@ -28,6 +28,9 @@
     "tailwind-merge": "^2.2.1",
     "tailwindcss": "^3.2.7",
     "vanilla-cookieconsent": "^3.0.1",
+    "react-error-boundary": "^3.1.4",
+    "helmet": "^7.0.0",
+    "express-rate-limit": "^6.7.0",
     "wasp": "file:.wasp/out/sdk/wasp",
     "zod": "^3.23.8"
   },

--- a/template/app/src/admin/layout/Sidebar.tsx
+++ b/template/app/src/admin/layout/Sidebar.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { storage } from '../../shared/storageAdapter';
 import { NavLink, useLocation } from 'react-router-dom';
 import Logo from '../../client/static/logo.webp';
 import SidebarLinkGroup from './SidebarLinkGroup';
@@ -16,10 +17,15 @@ const Sidebar = ({ sidebarOpen, setSidebarOpen }: SidebarProps) => {
   const trigger = useRef<any>(null);
   const sidebar = useRef<any>(null);
 
-  const storedSidebarExpanded = localStorage.getItem('sidebar-expanded');
-  const [sidebarExpanded, setSidebarExpanded] = useState(
-    storedSidebarExpanded === null ? false : storedSidebarExpanded === 'true'
-  );
+  const [sidebarExpanded, setSidebarExpanded] = useState(false);
+
+  useEffect(() => {
+    storage.get('sidebar-expanded').then((value) => {
+      if (value !== null) {
+        setSidebarExpanded(value === 'true' || value === true);
+      }
+    });
+  }, []);
 
   // close on click outside
   useEffect(() => {
@@ -43,7 +49,7 @@ const Sidebar = ({ sidebarOpen, setSidebarOpen }: SidebarProps) => {
   });
 
   useEffect(() => {
-    localStorage.setItem('sidebar-expanded', sidebarExpanded.toString());
+    storage.set('sidebar-expanded', sidebarExpanded.toString());
     if (sidebarExpanded) {
       document.querySelector('body')?.classList.add('sidebar-expanded');
     } else {

--- a/template/app/src/client/App.tsx
+++ b/template/app/src/client/App.tsx
@@ -1,6 +1,7 @@
 import './Main.css';
 import NavBar from './components/NavBar/NavBar';
-import CookieConsentBanner from './components/cookie-consent/Banner';
+import ErrorBoundary from './components/ErrorBoundary';
+import ConsentBanner from './components/ConsentBanner';
 import { appNavigationItems } from './components/NavBar/contentSections';
 import { landingPageNavigationItems } from '../landing-page/contentSections';
 import { useMemo, useEffect } from 'react';
@@ -38,7 +39,7 @@ export default function App() {
   }, [location]);
 
   return (
-    <>
+    <ErrorBoundary>
       <div className='min-h-screen dark:text-white dark:bg-boxdark-2'>
         {isAdminDashboard ? (
           <Outlet />
@@ -51,7 +52,7 @@ export default function App() {
           </>
         )}
       </div>
-      <CookieConsentBanner />
-    </>
+      <ConsentBanner />
+    </ErrorBoundary>
   );
 }

--- a/template/app/src/client/components/ConsentBanner.tsx
+++ b/template/app/src/client/components/ConsentBanner.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+/**
+ * Basic GDPR/consent banner. Shows once until accepted.
+ * TODO: Persist acceptance using storage adapter.
+ */
+export default function ConsentBanner() {
+  const [accepted, setAccepted] = useState(false);
+
+  if (accepted) return null;
+
+  return (
+    <div className="fixed bottom-0 inset-x-0 p-4 bg-gray-900 text-white text-center z-50">
+      <p className="mb-2 text-sm">We use cookies to improve your experience.</p>
+      <Button
+        onClick={() => {
+          setAccepted(true);
+          // TODO: persist acceptance
+        }}
+        className="bg-tcof-teal hover:bg-tcof-teal/90"
+      >
+        Accept
+      </Button>
+    </div>
+  );
+}

--- a/template/app/src/client/components/ErrorBoundary.tsx
+++ b/template/app/src/client/components/ErrorBoundary.tsx
@@ -1,0 +1,44 @@
+import { ReactNode } from 'react';
+import { ErrorBoundary as ReactErrorBoundary, FallbackProps } from 'react-error-boundary';
+import { Button } from '@/components/ui/button';
+
+function DefaultFallback({ error, resetErrorBoundary }: FallbackProps) {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-4 bg-gray-50">
+      <div className="bg-white p-8 rounded-lg shadow-md max-w-md w-full text-center">
+        <h1 className="text-2xl font-bold text-red-600 mb-4">App Error – Safe Mode</h1>
+        <p className="text-gray-700 mb-6">An unexpected error occurred.</p>
+        <div className="flex flex-col gap-4">
+          <Button onClick={resetErrorBoundary} className="w-full bg-tcof-teal hover:bg-tcof-teal/90 text-white">
+            Reload Application
+          </Button>
+        </div>
+        <details className="mt-6 text-left">
+          <summary className="cursor-pointer text-sm text-gray-500">Error Details</summary>
+          <pre className="mt-2 p-2 bg-gray-100 rounded text-xs overflow-auto">{error.message}</pre>
+        </details>
+      </div>
+    </div>
+  );
+}
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+  onError?: (error: Error, info: { componentStack: string }) => void;
+}
+
+/**
+ * Top-level error boundary using react-error-boundary.
+ * Wraps application UI and prevents hard crashes.
+ */
+export default function ErrorBoundary({ children, fallback, onError }: Props) {
+  return (
+    <ReactErrorBoundary
+      FallbackComponent={fallback ? () => <>{fallback}</> : DefaultFallback}
+      onError={onError}
+    >
+      {children}
+    </ReactErrorBoundary>
+  );
+}

--- a/template/app/src/client/hooks/useLocalStorage.tsx
+++ b/template/app/src/client/hooks/useLocalStorage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { storage } from '../../shared/storageAdapter';
 
 type SetValue<T> = T | ((val: T) => T);
 
@@ -8,33 +9,23 @@ function useLocalStorage<T>(
 ): [T, (value: SetValue<T>) => void] {
   // State to store our value
   // Pass  initial state function to useState so logic is only executed once
-  const [storedValue, setStoredValue] = useState(() => {
-    try {
-      // Get from local storage by key
-      const item = window.localStorage.getItem(key);
-      // Parse stored json or if none return initialValue
-      return item ? JSON.parse(item) : initialValue;
-    } catch (error) {
-      // If error also return initialValue
-      console.log(error);
-      return initialValue;
-    }
-  });
+  const [storedValue, setStoredValue] = useState<T>(initialValue);
 
-  // useEffect to update local storage when the state changes
   useEffect(() => {
-    try {
-      // Allow value to be a function so we have same API as useState
-      const valueToStore =
-        typeof storedValue === 'function'
-          ? storedValue(storedValue)
-          : storedValue;
-      // Save state
-      window.localStorage.setItem(key, JSON.stringify(valueToStore));
-    } catch (error) {
-      // A more advanced implementation would handle the error case
-      console.log(error);
-    }
+    storage.get(key).then((item) => {
+      if (item !== null) {
+        setStoredValue(item);
+      }
+    });
+  }, [key]);
+
+  // Persist value when it changes
+  useEffect(() => {
+    const valueToStore =
+      typeof storedValue === 'function' ? storedValue(storedValue) : storedValue;
+    storage.set(key, valueToStore).catch((err) => {
+      console.error(err);
+    });
   }, [key, storedValue]);
 
   return [storedValue, setStoredValue];

--- a/template/app/src/server.ts
+++ b/template/app/src/server.ts
@@ -1,0 +1,6 @@
+import type { Express } from 'express';
+import { applySecurityMiddleware } from '../../server/middleware/security';
+
+export function serverSetupFn(app: Express) {
+  applySecurityMiddleware(app);
+}

--- a/template/app/src/shared/storageAdapter.ts
+++ b/template/app/src/shared/storageAdapter.ts
@@ -1,0 +1,35 @@
+/**
+ * Resilient browser storage wrapper used across the app.
+ * Provides async API and basic error handling around localStorage.
+ * TODO: extend with fallback strategies (e.g. cookies, IndexedDB).
+ */
+export class StorageAdapter {
+  async get(key: string): Promise<any | null> {
+    try {
+      const value = localStorage.getItem(key);
+      return value ? JSON.parse(value) : null;
+    } catch (err) {
+      console.error('StorageAdapter.get failed', err);
+      return null;
+    }
+  }
+
+  async set(key: string, value: any): Promise<void> {
+    try {
+      const stringValue = typeof value === 'string' ? value : JSON.stringify(value);
+      localStorage.setItem(key, stringValue);
+    } catch (err) {
+      console.error('StorageAdapter.set failed', err);
+    }
+  }
+
+  async remove(key: string): Promise<void> {
+    try {
+      localStorage.removeItem(key);
+    } catch (err) {
+      console.error('StorageAdapter.remove failed', err);
+    }
+  }
+}
+
+export const storage = new StorageAdapter();


### PR DESCRIPTION
## Summary
- add ErrorBoundary and ConsentBanner components to client
- add storage adapter utility
- integrate components in App and Sidebar
- register security middleware via server setup
- include new deps in package.json

## Testing
- `npm run test --if-present` *(fails: no script)*
- `wasp db migrate-dev` *(fails: command not found)*